### PR TITLE
Added back HTML5 UP attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,11 @@
 <!DOCTYPE HTML>
+<!--
+	by HTML5 UP
+	html5up.net | @ajlkn
+	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+-->
+
+
 <html>
 
 <head>


### PR DESCRIPTION
No idea when it got stripped out, but thanks to @oliverjam for noticing.