### PR TITLE
adds url for twitter card image

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 	<meta property="og:image" content="images/social-preview-new.png">
 	<meta property="og:url" content="http://techforbetter.foundersandcoders.com/">
 	<meta name="twitter:card" content="summary_large_image">
-	<meta name="twitter:image" content="images/twitter-card.png">
+	<meta name="twitter:image" content="https://raw.githubusercontent.com/foundersandcoders/techforbetter-website/master/images/social-preview-new.png">
 	<link rel="stylesheet" href="assets/css/main.css">
 	<link rel="shortcut icon" href="images/favicon.ico">
 	<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->


### PR DESCRIPTION
Twitter card image still not displaying -- [documentation](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html) suggests a URL is required, so link to local image is perhaps the problem? Replaced with URL to image on GitHub.

Relates #56 