### PR TITLE
Hyperlinked logos so as to ask for permission to use them

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -372,10 +372,10 @@ li ul {
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(3, 1fr);
     align-items: center;                    /*Sort of aligns the logos*/
+    justify-items: center;
 }
 
 .partners-item {
-    place-self: center;
     width: calc((850px / 4) - 16px);
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -57,6 +57,7 @@ header {
     width: 100vw;
     color: white;
     font-size: 1rem;
+    z-index: 0;             /*Set to 0 to prevent vertical line from showming in MS Edge*/
 }
 
 #header-background {
@@ -370,6 +371,7 @@ li ul {
 .partners-grid {
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(3, 1fr);
+    align-items: center;                    /*Sort of aligns the logos*/
 }
 
 .partners-item {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -485,7 +485,7 @@ form {
     width: 100%;
     display: flex;
     flex-direction: row;
-    justify-contents: center;
+    justify-content: center;
 }
 
 .form-input {
@@ -662,7 +662,7 @@ footer .button:hover {
         place-self: center;
         width: calc((80vw / 3) - 16px);
     }
-    
+
     .sponsor-item {
         width: 80vw;
     }

--- a/index.html
+++ b/index.html
@@ -182,29 +182,29 @@
 				<h2 class="section-header">People We've Worked With</h2>
 			</div>
 			<div class="grid partners-grid">
-				<a href='https://www.annafreud.org/'>
+				<a href="https://www.annafreud.org/" target="_blank">
 				<img class="partners-item" src='images/portfolio/anna_freud.png' alt="anna freud logo" /></a>
-				<a href='http://www.bbk.ac.uk/'>
+				<a href="http://www.bbk.ac.uk/" target="_blank">
 				<img class="partners-item" src='images/portfolio/birkbeck.png' alt="birkbeck college logo" /></a>
-				<a href='http://cindex.camden.gov.uk/kb5/camden/cd/home.page'>
+				<a href="http://cindex.camden.gov.uk/kb5/camden/cd/home.page" target="_blank">
 				<img class="partners-item" src='images/portfolio/camden.png' alt="camden council logo" /></a>
-				<a href='https://wearecast.org.uk/'>
+				<a href="https://wearecast.org.uk/" target="_blank">
 				<img class="partners-item" src='images/portfolio/cast.png' alt="centre for acceleration of social technology logo" /></a>
-				<a href='https://www.learningtrust.co.uk/'>
+				<a href="https://www.learningtrust.co.uk/" target="_blank">
 				<img class="partners-item" src='images/portfolio/hackney_learning_trust.png' alt="hackney learning trust logo" /></a>
-				<a href='https://www.england.nhs.uk/'>
+				<a href="https://www.england.nhs.uk/" target="_blank">
 				<img class="partners-item" src='images/portfolio/nhs.png' alt="nhs england logo" /></a>
-				<a href='https://onpurpose.org/en/'>
+				<a href="https://onpurpose.org/en/" target="_blank">
 				<img class="partners-item" src='images/portfolio/on_purpose.png' alt="on purpose logo" /></a>
-				<a href='https://www.qmul.ac.uk/'>
+				<a href="https://www.qmul.ac.uk/" target="_blank">
 				<img class="partners-item" src='images/portfolio/queen_mary_uni.png' alt="queen mary university logo"/></a>
-				<a href='http://www.roundabouthomeless.org/'>
+				<a href="http://www.roundabouthomeless.org/" target="_blank">
 				<img class="partners-item" src='images/portfolio/roundabout.png' alt="roundabout homeless charity logo" /></a>
-				<a href='https://www.royalholloway.ac.uk/'>
+				<a href="https://www.royalholloway.ac.uk/" target="_blank">
 				<img class="partners-item" src='images/portfolio/royal_holloway.png' alt="royal holloway logo"/></a>
-				<a href='http://www.safelives.org.uk/'>
+				<a href="http://www.safelives.org.uk/" target="_blank">
 					<img class="partners-item" src='images/portfolio/safe_lives.png' alt="safe lives logo" /></a>
-				<a href='http://safertogether.org.uk/'>
+				<a href="http://safertogether.org.uk/" target="_blank">
 					<img class="partners-item" src='images/portfolio/safer_together.png' alt="safer together logo"/></a>>
 			</div>
 		</section>

--- a/index.html
+++ b/index.html
@@ -176,24 +176,36 @@
 			</div>
 			</div>
 		</section>
-
+<a href=''></a>
 		<section>
 			<div class="border">
 				<h2 class="section-header">People We've Worked With</h2>
 			</div>
 			<div class="grid partners-grid">
-				<img class="partners-item" src='images/portfolio/anna_freud.png' alt="anna freud logo" />
-				<img class="partners-item" src='images/portfolio/birkbeck.png' alt="birkbeck college logo" />
-				<img class="partners-item" src='images/portfolio/camden.png' alt="camden council logo" />
-				<img class="partners-item" src='images/portfolio/cast.png' alt="centre for acceleration of social technology logo" />
-				<img class="partners-item" src='images/portfolio/hackney_learning_trust.png' alt="hackney learning trust logo" />
-				<img class="partners-item" src='images/portfolio/nhs.png' alt="nhs england logo" />
-				<img class="partners-item" src='images/portfolio/on_purpose.png' alt="on purpose logo" />
-				<img class="partners-item" src='images/portfolio/queen_mary_uni.png' alt="queen mary university logo" />
-				<img class="partners-item" src='images/portfolio/roundabout.png' alt="roundabout homeless charity logo" />
-				<img class="partners-item" src='images/portfolio/royal_holloway.png' alt="royal holloway logo" />
-				<img class="partners-item" src='images/portfolio/safe_lives.png' alt="safe lives logo" />
-				<img class="partners-item" src='images/portfolio/safer_together.png' alt="safer together logo" />
+				<a href='https://www.annafreud.org/'>
+				<img class="partners-item" src='images/portfolio/anna_freud.png' alt="anna freud logo" /></a>
+				<a href='http://www.bbk.ac.uk/'>
+				<img class="partners-item" src='images/portfolio/birkbeck.png' alt="birkbeck college logo" /></a>
+				<a href='http://cindex.camden.gov.uk/kb5/camden/cd/home.page'>
+				<img class="partners-item" src='images/portfolio/camden.png' alt="camden council logo" /></a>
+				<a href='https://wearecast.org.uk/'>
+				<img class="partners-item" src='images/portfolio/cast.png' alt="centre for acceleration of social technology logo" /></a>
+				<a href='https://www.learningtrust.co.uk/'>
+				<img class="partners-item" src='images/portfolio/hackney_learning_trust.png' alt="hackney learning trust logo" /></a>
+				<a href='https://www.england.nhs.uk/'>
+				<img class="partners-item" src='images/portfolio/nhs.png' alt="nhs england logo" /></a>
+				<a href='https://onpurpose.org/en/'>
+				<img class="partners-item" src='images/portfolio/on_purpose.png' alt="on purpose logo" /></a>
+				<a href='https://www.qmul.ac.uk/'>
+				<img class="partners-item" src='images/portfolio/queen_mary_uni.png' alt="queen mary university logo"/></a>
+				<a href='http://www.roundabouthomeless.org/'>
+				<img class="partners-item" src='images/portfolio/roundabout.png' alt="roundabout homeless charity logo" /></a>
+				<a href='https://www.royalholloway.ac.uk/'>
+				<img class="partners-item" src='images/portfolio/royal_holloway.png' alt="royal holloway logo"/></a>
+				<a href='http://www.safelives.org.uk/'>
+					<img class="partners-item" src='images/portfolio/safe_lives.png' alt="safe lives logo" /></a>
+				<a href='http://safertogether.org.uk/'>
+					<img class="partners-item" src='images/portfolio/safer_together.png' alt="safer together logo"/></a>>
 			</div>
 		</section>
 

--- a/index.html
+++ b/index.html
@@ -176,7 +176,6 @@
 			</div>
 			</div>
 		</section>
-<a href=''></a>
 		<section>
 			<div class="border">
 				<h2 class="section-header">People We've Worked With</h2>
@@ -205,7 +204,7 @@
 				<a href="http://www.safelives.org.uk/" target="_blank">
 					<img class="partners-item" src='images/portfolio/safe_lives.png' alt="safe lives logo" /></a>
 				<a href="http://safertogether.org.uk/" target="_blank">
-					<img class="partners-item" src='images/portfolio/safer_together.png' alt="safer together logo"/></a>>
+					<img class="partners-item" src='images/portfolio/safer_together.png' alt="safer together logo"/></a>
 			</div>
 		</section>
 


### PR DESCRIPTION
Reasons for linking to the websites whose logos we're currently using without permission:
1. It's a matter of www courtesy.
2. Not linking goes against the community spirit we're advocating.
3. Clickable logos is what users expect.
4. Linking out to other websites encourages linking in to ours.